### PR TITLE
Bump libs versions for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-aiogram==3.7.0
+aiogram==3.27.0
 aiogram-newsletter>=0.0.10
 cachetools==5.3.2
 environs==14.1.1
-pydantic==2.5.3
+pydantic==2.12.5
 redis==5.0.1


### PR DESCRIPTION
Update dependencies for Python 3.13 compatibility.

- Bump pydantic to 2.12.5, as pydantic 2.8+ is required for Python 3.13.
- Bump aiogram to 3.27.0 to use a version compatible with the updated pydantic dependency.

Changelogs:

- [pydantic](https://github.com/pydantic/pydantic/releases)
- [aiogram](https://github.com/aiogram/aiogram/releases)